### PR TITLE
Silence pull request security warnings

### DIFF
--- a/groups/cdn/cloudfront.tf
+++ b/groups/cdn/cloudfront.tf
@@ -1,4 +1,4 @@
-#trivy:ignore:avd-aws-0011
+#trivy:ignore:AVD-AWS-0011
 resource "aws_cloudfront_distribution" "cdn" {
   enabled             = true
   http_version        = "http2and3"

--- a/groups/cdn/cloudfront.tf
+++ b/groups/cdn/cloudfront.tf
@@ -1,3 +1,4 @@
+#trivy:ignore:avd-aws-0011
 resource "aws_cloudfront_distribution" "cdn" {
   enabled             = true
   http_version        = "http2and3"

--- a/groups/cdn/cloudfront.tf
+++ b/groups/cdn/cloudfront.tf
@@ -1,4 +1,4 @@
-#trivy:ignore:AVD-AWS-0011
+#trivy:ignore:AVD-AWS-0011 AVD-AWS-0013
 resource "aws_cloudfront_distribution" "cdn" {
   enabled             = true
   http_version        = "http2and3"

--- a/groups/cdn/cloudfront.tf
+++ b/groups/cdn/cloudfront.tf
@@ -1,4 +1,5 @@
-#trivy:ignore:AVD-AWS-0011 AVD-AWS-0013
+#trivy:ignore:AVD-AWS-0011
+#trivy:ignore:AVD-AWS-0013
 resource "aws_cloudfront_distribution" "cdn" {
   enabled             = true
   http_version        = "http2and3"

--- a/groups/cdn/cloudfront.tf
+++ b/groups/cdn/cloudfront.tf
@@ -1,5 +1,4 @@
-#trivy:ignore:AVD-AWS-0011
-#trivy:ignore:AVD-AWS-0013
+#trivy:ignore:AVD-AWS-0011 trivy:ignore:AVD-AWS-0013
 resource "aws_cloudfront_distribution" "cdn" {
   enabled             = true
   http_version        = "http2and3"

--- a/groups/cdn/s3.tf
+++ b/groups/cdn/s3.tf
@@ -2,7 +2,7 @@ resource "aws_s3_bucket" "s3_bucket" {
   bucket = "${var.service}.${var.aws_account}.ch.gov.uk"
 }
 
-#trivy:ignore:avd-aws-0132
+#trivy:ignore:AVD-AWS-0132
 resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_encryption" {
   bucket = aws_s3_bucket.s3_bucket.id
 
@@ -41,7 +41,7 @@ resource "aws_s3_bucket" "logs" {
   bucket = "${var.service}-access-logs.${var.aws_account}.ch.gov.uk"
 }
 
-#trivy:ignore:avd-aws-0132
+#trivy:ignore:AVD-AWS-0132
 resource "aws_s3_bucket_server_side_encryption_configuration" "logs" {
   bucket = aws_s3_bucket.logs.id
 

--- a/groups/cdn/s3.tf
+++ b/groups/cdn/s3.tf
@@ -2,6 +2,7 @@ resource "aws_s3_bucket" "s3_bucket" {
   bucket = "${var.service}.${var.aws_account}.ch.gov.uk"
 }
 
+#trivy:ignore:avd-aws-0132
 resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_encryption" {
   bucket = aws_s3_bucket.s3_bucket.id
 
@@ -40,6 +41,7 @@ resource "aws_s3_bucket" "logs" {
   bucket = "${var.service}-access-logs.${var.aws_account}.ch.gov.uk"
 }
 
+#trivy:ignore:avd-aws-0132
 resource "aws_s3_bucket_server_side_encryption_configuration" "logs" {
   bucket = aws_s3_bucket.logs.id
 


### PR DESCRIPTION
Justification for rule exclusions:

- [AVD-AWS-0011](https://avd.aquasec.com/misconfig/aws/cloudfront/avd-aws-0011/) - the CloudFront origin is not a dynamic web application but an S3 bucket holding static resources that are distributed directly to user agents, meaning a WAF rule is likely to offer little additional protection
- [AVD-AWS-0013](https://avd.aquasec.com/misconfig/aws/cloudfront/avd-aws-0013/) - restricting the minimum TLS protocol version to `TLSv1.2_2021` is _only_ possible when not using the default CloudFront certificate and domain (`cloudfront.net`); there are currently no plans to adopt a custom domain, however this may be revisited at some future date, at which point the minimum TLS version may be increased and this rule exclusion removed
- [AVD-AWS-0132](https://avd.aquasec.com/misconfig/aws/s3/avd-aws-0132/) - all content stored in the S3 CDN bucket is distributed publicly via CHS services and Customer Managed Keys offer little advantage over S3-managed keys; the access logs bucket will be replaced in the near future with a shared bucket managed outside of this project