### PR TITLE
Update bucket policy

### DIFF
--- a/groups/cdn/data.tf
+++ b/groups/cdn/data.tf
@@ -84,7 +84,29 @@ data "aws_iam_policy_document" "logs" {
   }
 }
 
-data "aws_iam_policy_document" "s3_bucket_policy" {
+data "aws_iam_policy_document" "assets" {
+  statement {
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.cdn.arn]
+    }
+
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.s3_bucket.arn}/*",
+    ]
+  }
+
   statement {
     sid = "DenyNonSSLRequests"
 
@@ -109,30 +131,6 @@ data "aws_iam_policy_document" "s3_bucket_policy" {
       variable = "aws:SecureTransport"
       values   = ["false"]
     }
-  }
-}
-
-data "aws_iam_policy_document" "s3_cloudfront_policy" {
-  statement {
-
-    principals {
-      type        = "Service"
-      identifiers = ["cloudfront.amazonaws.com"]
-    }
-
-    condition {
-      test     = "StringEquals"
-      variable = "AWS:SourceArn"
-      values   = [aws_cloudfront_distribution.cdn.arn]
-    }
-
-    actions = [
-      "s3:GetObject",
-    ]
-
-    resources = [
-      "${aws_s3_bucket.s3_bucket.arn}/*",
-    ]
   }
 }
 

--- a/groups/cdn/s3.tf
+++ b/groups/cdn/s3.tf
@@ -33,7 +33,7 @@ resource "aws_s3_bucket_public_access_block" "bucket_public_access" {
 
 resource "aws_s3_bucket_policy" "bucket_policy" {
   bucket = aws_s3_bucket.s3_bucket.id
-  policy = data.aws_iam_policy_document.s3_cloudfront_policy.json
+  policy = data.aws_iam_policy_document.assets.json
 }
 
 resource "aws_s3_bucket" "logs" {


### PR DESCRIPTION
This change combines an unused policy statement with the actual S3 assets bucket policy to ensure strict transport protocols are required for actions targeting the bucket and its objects.