### PR TITLE
CC-1658 - Enable configurable CORS for CDN environments

### DIFF
--- a/groups/cdn/profiles/development-eu-west-2/vars
+++ b/groups/cdn/profiles/development-eu-west-2/vars
@@ -22,3 +22,7 @@ environments = [
   "titans1",
   "toro1"
 ]
+
+cors_allowed_origins = [
+  "https://*.aws.chdev.org"
+]

--- a/groups/cdn/profiles/live-eu-west-2/vars
+++ b/groups/cdn/profiles/live-eu-west-2/vars
@@ -1,5 +1,10 @@
 aws_account = "live"
 
 environments = [
-    "live"
+  "live"
+]
+
+cors_allowed_origins = [
+  "https://*.company-information-service.gov.uk",
+  "https://*.companieshouse.gov.uk"
 ]

--- a/groups/cdn/profiles/staging-eu-west-2/vars
+++ b/groups/cdn/profiles/staging-eu-west-2/vars
@@ -1,5 +1,11 @@
 aws_account = "staging"
 
 environments = [
-    "staging"
+  "staging"
+]
+
+cors_allowed_origins = [
+  "https://*staging*company-information-service.gov.uk",
+  "https://*staging*.companieshouse.gov.uk",
+  "https://*stg*.companieshouse.gov.uk"
 ]

--- a/groups/cdn/s3.tf
+++ b/groups/cdn/s3.tf
@@ -36,6 +36,18 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "assets" {
   }
 }
 
+resource "aws_s3_bucket_cors_configuration" "assets" {
+  bucket = aws_s3_bucket.assets.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "HEAD"]
+    allowed_origins = var.cors_allowed_origins
+    expose_headers  = ["Access-Control-Allow-Origin"]
+    max_age_seconds = 3000
+  }
+}
+
 module "s3_access_logging" {
   source = "git@github.com:companieshouse/terraform-modules//aws/s3_access_logging?ref=1.0.293"
 

--- a/groups/cdn/variables.tf
+++ b/groups/cdn/variables.tf
@@ -36,3 +36,8 @@ variable "service" {
   description = "The service name to be used when creating AWS resources"
   default     = "chs-cdn"
 }
+
+variable "cors_allowed_origins" {
+  type        = set(string)
+  description = "The origins which are allowed to access assets cross-origin"
+}


### PR DESCRIPTION
Enable CORS for the different s3 buckets environments.

This is currently manually enabled for CIDev and synced team e.g. rebel1 environments, but does not exist for staging and live.

This change introduces to them all and allows configuration of the origin per environment.

Existing manual configuration on CIDev:

```json
[
    {
        "AllowedHeaders": [
            "*"
        ],
        "AllowedMethods": [
            "GET",
            "HEAD"
        ],
        "AllowedOrigins": [
            "https://*.aws.chdev.org"
        ],
        "ExposeHeaders": [
            "Access-Control-Allow-Origin"
        ],
        "MaxAgeSeconds": 3000
    }
]
```

Changes are based on https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_cors_configuration