### PR TITLE
CC-1660 - Remove redundant cache configuration

### DIFF
--- a/groups/cdn/cloudfront.tf
+++ b/groups/cdn/cloudfront.tf
@@ -25,10 +25,6 @@ resource "aws_cloudfront_distribution" "assets" {
     origin_request_policy_id = aws_cloudfront_origin_request_policy.assets.id
 
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = var.min_ttl
-    default_ttl            = var.default_ttl
-    max_ttl                = var.max_ttl
-    compress               = true
   }
 
   restrictions {


### PR DESCRIPTION
This configuration is duplicate to the configuration being set in the shared cache policy.

`compress` is covered by `enable_accept_encoding_brotli` and `enable_accept_encoding_gzip`.

https://github.com/companieshouse/cdn-terraform/blob/c4409b051daf38ce2038d001bc45916912a2e7df/groups/cdn/cloudfront.tf#L59-L61

`min_ttl`, `max_ttl` and `default_ttl` are covered by arguments of the same name.

https://github.com/companieshouse/cdn-terraform/blob/c4409b051daf38ce2038d001bc45916912a2e7df/groups/cdn/cloudfront.tf#L76-L77

This change is motivated by trying to stop terraform plan from showing unnecessary changes.