### PR TITLE
CC-1989 - Allow origin to determine cache key and forwarded

### DIFF
--- a/groups/cdn/cloudfront.tf
+++ b/groups/cdn/cloudfront.tf
@@ -58,7 +58,10 @@ resource "aws_cloudfront_cache_policy" "assets" {
 
   parameters_in_cache_key_and_forwarded_to_origin {
     headers_config {
-      header_behavior = "none"
+      header_behavior = "whitelist"
+      headers {
+        items = ["Origin"]
+      }
     }
 
     cookies_config {


### PR DESCRIPTION
We're seeing responses return which are failing because the origin is for example accounts.cidev vs cidev.

We believe this is because which ever origin requests the asset first will set the origin and be cached creating a mismatch.

By forwarding the origin we hope to avoid this.