### PR TITLE
Move CORS configuration from S3 to CloudFront

### DIFF
--- a/groups/cdn/cloudfront.tf
+++ b/groups/cdn/cloudfront.tf
@@ -89,3 +89,25 @@ resource "aws_cloudfront_origin_request_policy" "assets" {
     query_string_behavior = "none"
   }
 }
+
+resource "aws_cloudfront_response_headers_policy" "assets" {
+  name    = "${var.service}-${var.aws_account}-shared-policy"
+
+  cors_config {
+    origin_override = false
+    access_control_allow_credentials = false
+    access_control_max_age_sec = 3000
+
+    access_control_allow_headers {
+      items = "*"
+    }
+
+    access_control_allow_methods {
+      items = ["GET", "HEAD"]
+    }
+
+    access_control_allow_origins {
+      items = var.cors_allowed_origins
+    }
+  }
+}

--- a/groups/cdn/s3.tf
+++ b/groups/cdn/s3.tf
@@ -36,18 +36,6 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "assets" {
   }
 }
 
-resource "aws_s3_bucket_cors_configuration" "assets" {
-  bucket = aws_s3_bucket.assets.id
-
-  cors_rule {
-    allowed_headers = ["*"]
-    allowed_methods = ["GET", "HEAD"]
-    allowed_origins = var.cors_allowed_origins
-    expose_headers  = ["Access-Control-Allow-Origin"]
-    max_age_seconds = 3000
-  }
-}
-
 module "s3_access_logging" {
   source = "git@github.com:companieshouse/terraform-modules//aws/s3_access_logging?ref=1.0.307"
 


### PR DESCRIPTION
Allows us to consolidate CDN configuration and set access_control_allow_credentials to false where we use wildcard domains, to avoid any potential for CSRF attacks.