### PR TITLE
Add new allowed origin for admin services to pull cdn assets

### DIFF
--- a/groups/cdn/profiles/live-eu-west-2/vars
+++ b/groups/cdn/profiles/live-eu-west-2/vars
@@ -5,6 +5,7 @@ environments = [
 ]
 
 cors_allowed_origins = [
+  "https://admin-web.company-information.service.gov.uk",
   "https://beta.companieshouse.gov.uk",
   "https://find-and-update.company-information.service.gov.uk",
   "https://identity.company-information.service.gov.uk",

--- a/groups/cdn/profiles/staging-eu-west-2/vars
+++ b/groups/cdn/profiles/staging-eu-west-2/vars
@@ -5,6 +5,7 @@ environments = [
 ]
 
 cors_allowed_origins = [
+  "https://admin-web-staging.company-information.service.gov.uk",
   "https://staging-aws.companieshouse.gov.uk",
   "https://staging.company-information.service.gov.uk",
   "https://identity-staging.company-information.service.gov.uk",


### PR DESCRIPTION
In staging a new admin service identity-verification-web couldn't pull it's assets from the old CDN process. Now that's resolved need to also set up the new cloudfront dist with an allowed origin for the admin sites.