### PR TITLE
Disable S3 bucket keys

### DIFF
--- a/groups/cdn/s3.tf
+++ b/groups/cdn/s3.tf
@@ -29,7 +29,6 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "assets" {
   bucket = aws_s3_bucket.assets.id
 
   rule {
-    bucket_key_enabled = true
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
     }


### PR DESCRIPTION
This change disables [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html) — a cost-optimisation feature only applicable when using `SSE-KMS`. AWS APIs may omit or ignore this setting when `AES256` (i.e. `SSE-S3`) is configured, which can lead to Terraform repeatedly detecting a difference between configuration and observed state.