### PR TITLE
Enable cloudfront compression

### DIFF
--- a/groups/cdn/cloudfront.tf
+++ b/groups/cdn/cloudfront.tf
@@ -20,6 +20,7 @@ resource "aws_cloudfront_distribution" "assets" {
     allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = local.cloudfront_shared_origin_id
+    compress         = true
 
     cache_policy_id          = aws_cloudfront_cache_policy.assets.id
     origin_request_policy_id = aws_cloudfront_origin_request_policy.assets.id


### PR DESCRIPTION
## CDN rework - [DVOP-5136](https://companieshouse.atlassian.net/browse/DVOP-5136)

## What
Adds compress = true to the `default_cache_behavior` block in `groups/cdn/cloudfront.tf`

## Why
compress has never been set in this configuration, so it defaults to false. that means dev and staging distributions serve assets uncompressed.

Live is currently `compress = true` which doesn’t match the code, live hasn’t had a terraform apply since Nov 2024, so nothing had compared its real config against the code until recently.

This surfaced while running a [live-plan](https://ci-platform.companieshouse.gov.uk/teams/team-infrastructure/pipelines/chs-cdn/jobs/live-plan/builds/12) as part of the CDN rework work ([live-sync: DVOP-5149](https://companieshouse.atlassian.net/jira/software/c/projects/DVOP/boards/1064?selectedIssue=DVOP-5149)). Without this change, applying that plan would flip live’s compression off

The cache policy already has `enable_accept_encoding_gzip` and `enable_accept_encoding_brotli` set to true, so compression appears to have been intended and the distribution attribute was absent

[DVOP-5136]: https://companieshouse.atlassian.net/browse/DVOP-5136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ